### PR TITLE
swap "compare active file with clipboard"

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,33 +1,33 @@
 import * as vscode from "vscode";
 
 export function activate(context: vscode.ExtensionContext) {
-  const documentScheme = /^(file|untitled|clipboardCompare\d+)$/;
-
   let disposable = vscode.commands.registerCommand("swapdiff.swapdiff", () => {
-    const files: vscode.Uri[] = [];
-    for (let editor of vscode.window.visibleTextEditors) {
-      if (documentScheme.test(editor.document.uri.scheme)) {
-        files.push(editor.document.uri);
-      }
+    const tab = vscode.window.tabGroups.activeTabGroup.activeTab;
+    const input = tab?.input;
+    const isDiffTab =
+      input instanceof vscode.TabInputTextDiff ||
+      input instanceof vscode.TabInputNotebookDiff;
+
+    if (!tab || !isDiffTab) {
+      vscode.window.showWarningMessage("Nothing to swap :(");
+      return;
     }
 
-    const opened = files.length;
+    const newLabel = tab.label.split(" ↔ ").reverse().join(" ↔ ");
 
-    if (opened <= 1) {
-      vscode.window.showWarningMessage("Nothing to swap :(");
-    } else if (opened === 2) {
-      const closePrevious = vscode.workspace
-        .getConfiguration()
-        .get("swapdiff.ClosePreviousDiff");
-      if (closePrevious) {
-        vscode.commands.executeCommand("workbench.action.closeActiveEditor");
-      }
+    vscode.commands.executeCommand(
+      "vscode.diff",
+      input.modified,
+      input.original,
+      newLabel
+    );
 
-      vscode.commands.executeCommand("vscode.diff", files[1], files[0]);
-    } else {
-      vscode.window.showWarningMessage(
-        "More than 2 visible files, can`t swap it :("
-      );
+    const closePrevious = vscode.workspace
+      .getConfiguration()
+      .get("swapdiff.ClosePreviousDiff");
+
+    if (closePrevious) {
+      vscode.window.tabGroups.close(tab);
     }
   });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,12 @@
 import * as vscode from "vscode";
 
 export function activate(context: vscode.ExtensionContext) {
-  const documentScheme = ["file", "untitled"];
+  const documentScheme = /^(file|untitled|clipboardCompare\d+)$/;
 
   let disposable = vscode.commands.registerCommand("swapdiff.swapdiff", () => {
     const files: vscode.Uri[] = [];
     for (let editor of vscode.window.visibleTextEditors) {
-      if (documentScheme.includes(editor.document.uri.scheme)) {
+      if (documentScheme.test(editor.document.uri.scheme)) {
         files.push(editor.document.uri);
       }
     }


### PR DESCRIPTION
Closes #23, I've also needed that feature so many times

The scheme format is defined in https://github.com/microsoft/vscode/blob/3aea4d643c8a2849d2d676ab619d81c83f8395b5/src/vs/workbench/contrib/files/browser/fileActions.ts#L813

